### PR TITLE
feat(front): Filter current date time from object or string

### DIFF
--- a/l2l/templates/l2l/index.html
+++ b/l2l/templates/l2l/index.html
@@ -1,5 +1,5 @@
 {% load static %}
-{#{% load l2l_extras %}#}
+{% load datetime_extras %}
 <!doctype html>
 <html lang="en">
     <head>
@@ -55,10 +55,10 @@
         <div class="col-md-5 p-lg-5 mx-auto my-5">
           <h1 class="display-4 fw-normal">Punny headline</h1>
           <p class="lead fw-normal">Yes this is a rip-off from one of Bootstrap's example html pages.</p>
-          <p class="lead fw-normal">Today's date is: {{ now }}</p>
-          <p class="lead fw-normal">Today's ISO date is: {{ iso }}</p>
-          {#<p class="lead fw-normal">Today's date from a date is: {{ now|l2l_dt }}</p>#}
-          {#<p class="lead fw-normal">Today's date from a string is: {{ iso|l2l_dt }}</p>#}
+          <p class="lead fw-normal">Today's date is: <br>{{ now }}</p>
+          <p class="lead fw-normal">Today's ISO date is: <br>{{ iso }}</p>
+          <p class="lead fw-normal">Today's date from a date is: <br>{{ now|to_numerical_datetime }}</p>
+          <p class="lead fw-normal">Today's date from a string is: <br>{{ iso|to_numerical_datetime }}</p>
           <a class="btn btn-outline-secondary" href="#">Coming soon</a>
         </div>
         <div class="product-device shadow-sm d-none d-md-block"></div>

--- a/l2l/templatetags/datetime_extras.py
+++ b/l2l/templatetags/datetime_extras.py
@@ -1,0 +1,17 @@
+from django import template
+import datetime
+register = template.Library()
+
+
+@register.filter(is_safe=True, expects_localtime=True)
+def to_numerical_datetime(date_time):
+
+    def convert_to_datetime_from_string():
+        nonlocal date_time
+        date_time = datetime.datetime.strptime(
+            date_time, "%Y-%m-%dT%H:%M:%S")
+
+    if type(date_time) is str:
+        convert_to_datetime_from_string()
+
+    return(date_time.strftime("%Y-%m-%d %H:%M:%S"))


### PR DESCRIPTION
- Add support to display current date and 24 hour time from either a datetime object or an ISO string.